### PR TITLE
fetch_balance() correct arguments

### DIFF
--- a/build/ccxt.php
+++ b/build/ccxt.php
@@ -13292,7 +13292,7 @@ class hitbtc2 extends hitbtc {
         return $result;
     }
 
-    public function fetch_balance () {
+    public function fetch_balance ($params = array ()) {
         $this->load_markets ();
         $balances = $this->privateGetTradingBalance ();
         $result = array ( 'info' => $balances );


### PR DESCRIPTION
PHP Warning:  Declaration of ccxt\hitbtc2::fetch_balance() should be compatible with ccxt\hitbtc::fetch_balance($params = Array)