### PR TITLE
print error details anytime

### DIFF
--- a/ccxt/exchange.py
+++ b/ccxt/exchange.py
@@ -202,7 +202,10 @@ class Exchange(object):
                     details,
                 ])
             else:
-                details = str(error)
+                details = ' '.join([
+                    str(error),
+                    details,
+                ])
             raise exception_type(' '.join([
                 self.id,
                 method,


### PR DESCRIPTION
## problem

in ```raise_error``` function

details variable contains details of the error.
this variable will be overwritten under certain conditions.

## solution 

so I changed not to overwrite error details