### PR TITLE
hitbtc: v2 adaptations

### DIFF
--- a/ccxt.js
+++ b/ccxt.js
@@ -14812,17 +14812,6 @@ var hitbtc = {
         }, params));
     },
 
-    parseOrders (orders, market = undefined) {
-        let result = [];
-        let ids = Object.keys (orders);
-        for (let i = 0; i < ids.length; i++) {
-            let id = ids[i];
-            let order = this.extend ({ 'id': id }, orders[id]);
-            result.push (this.parseOrder (order, market));
-        }
-        return result;
-    },
-
     getOrderStatus (status) {
         let statuses = {
             'new': 'open',
@@ -15231,7 +15220,9 @@ var hitbtc2 = extend (hitbtc, {
         if (market)
             request['symbols'] = market['id'];
         let response = await this.privateGetOrder (this.extend (request, params));
-        return this.parseOrders (response['orders'], market);
+        console.log('open orders', response);
+
+        return this.parseOrders (response, market);
     },
 
     async withdraw (currency, amount, address, params = {}) {

--- a/ccxt.js
+++ b/ccxt.js
@@ -15044,6 +15044,12 @@ var hitbtc2 = extend (hitbtc, {
             ],
         },
     },
+    'fees': {
+        'trading': {
+            'maker': 0.0 / 100,
+            'taker': 0.1 / 100,
+        },
+    },
 
     async fetchMarkets () {
         let markets = await this.publicGetSymbol ();

--- a/ccxt.js
+++ b/ccxt.js
@@ -15062,7 +15062,7 @@ var hitbtc2 = extend (hitbtc, {
                 'step': step,
                 'info': market,
                 'precision': {
-                    'price': 8,
+                    'price': 2,
                     'amount': -1 * Math.log10(step),
                 },
                 'limits': {
@@ -15211,7 +15211,7 @@ var hitbtc2 = extend (hitbtc, {
     },
 
     parseOrder (order, market = undefined) {
-        let lastTime = new Date(order['updatedAt']);
+        let lastTime = this.parse8601 (order['updatedAt']);
         let timestamp = lastTime.getTime();
 
         if (!market)
@@ -15249,15 +15249,10 @@ var hitbtc2 = extend (hitbtc, {
 
     async fetchOpenOrders (symbol = undefined, params = {}) {
         await this.loadMarkets ();
-        //let statuses = [ 'new', 'partiallyFiiled' ];
-        //let request = {
-        //    'sort': 'desc',
-        //    'statuses': statuses.join (','),
-        //};
         let market;
         if (symbol) {
-          market = this.market (symbol);
-          params = this.extend ({'symbol': market['id']});
+            market = this.market (symbol);
+            params = this.extend ({'symbol': market['id']});
         }
         let response = await this.privateGetOrder (params);
 

--- a/ccxt.js
+++ b/ccxt.js
@@ -15212,6 +15212,28 @@ var hitbtc2 = extend (hitbtc, {
         }, params));
     },
 
+    async fetchOrder (id, symbol = undefined, params = {}) {
+        await this.loadMarkets ();
+        let response = await this.privateGetOrder (this.extend ({
+            'client_order_id': id,
+        }, params));
+        return this.parseOrder (response['orders'][0]);
+    },
+
+    async fetchOpenOrders (symbol = undefined, params = {}) {
+        await this.loadMarkets ();
+        let statuses = [ 'new', 'partiallyFiiled' ];
+        let market = this.market (symbol);
+        let request = {
+            'sort': 'desc',
+            'statuses': statuses.join (','),
+        };
+        if (market)
+            request['symbols'] = market['id'];
+        let response = await this.privateGetOrder (this.extend (request, params));
+        return this.parseOrders (response['orders'], market);
+    },
+
     async withdraw (currency, amount, address, params = {}) {
         await this.loadMarkets ();
         amount = parseFloat (amount);

--- a/ccxt.js
+++ b/ccxt.js
@@ -15249,7 +15249,7 @@ var hitbtc2 = extend (hitbtc, {
 
     async fetchOpenOrders (symbol = undefined, params = {}) {
         await this.loadMarkets ();
-        let market;
+        let market = undefined;
         if (symbol) {
             market = this.market (symbol);
             params = this.extend ({'symbol': market['id']});


### PR DESCRIPTION
Apparently, hitbtc v2 was partially implemented.

So now:
- fetchOpenOrders() adapted for new endpoint
- I removed child parseOrders() as it throwed an exception on empty array of orders. Base class method handles it just well
- order structure have been changed so I adapted `parseOrder()` as well
- limits and precisions was not compatible with the doc (market had `lot` and `step` properties instead but I kept them for backwards compatibility)
- trading fees added to market 