### PR TITLE
Add bitfinex price_precision

### DIFF
--- a/ccxt.js
+++ b/ccxt.js
@@ -3900,6 +3900,9 @@ var bitfinex = {
             if (base == 'DSH')
                 base = 'DASH';
             let symbol = base + '/' + quote;
+            let precision = {
+                'price': market['price_precision'],
+            };
             result.push ({
                 'id': id,
                 'symbol': symbol,
@@ -3908,6 +3911,7 @@ var bitfinex = {
                 'baseId': baseId,
                 'quoteId': quoteId,
                 'info': market,
+                'precision': precision,
             });
         }
         return result;


### PR DESCRIPTION
#371: Added `precision['price']` to `fetchMarkets()` for `bitfinex` class.

I'm unable to build it locally as discussed, but hopefully it works on your end.