### PR TITLE
amountToPrecision(): truncate, not round up

### DIFF
--- a/ccxt.js
+++ b/ccxt.js
@@ -1032,7 +1032,7 @@ const Exchange = function (config) {
     }
 
     this.amountToPrecision = function (symbol, amount) {
-        return parseFloat (amount).toFixed (this.markets[symbol].precision.amount)
+        return this.truncate(amount, this.markets[symbol].precision.amount)
     }
 
     this.feeToPrecision = function (symbol, fee) {


### PR DESCRIPTION
Affects order placement on liqui and quite probably all other exchanges. Now truncates `amount` so it won't throw InsufficientFunds exception if you try to sell all inventory.

I also got rid of `parseFloat()` as `truncate` converts `amount` to String anyway down the road.

Should fix #393.