### PR TITLE
btctradeua: parseTrade: add leading '0' when an hour is between [0..9]

### DIFF
--- a/ccxt.js
+++ b/ccxt.js
@@ -9419,7 +9419,7 @@ var btctradeua = {
         let year = parts[2];
         let hms = parts[4];
         if (hms.length == 7) {
-          hms = '0' + hms;
+            hms = '0' + hms;
         }
         let ymd = [ year, month, day ].join ('-');
         let ymdhms = ymd + 'T' + hms;

--- a/ccxt.js
+++ b/ccxt.js
@@ -9418,6 +9418,9 @@ var btctradeua = {
             throw new ExchangeError (this.id + ' parseTrade() undefined month name: ' + cyrillic);
         let year = parts[2];
         let hms = parts[4];
+        if (hms.length == 7) {
+          hms = '0' + hms;
+        }
         let ymd = [ year, month, day ].join ('-');
         let ymdhms = ymd + 'T' + hms;
         let timestamp = this.parse8601 (ymdhms);


### PR DESCRIPTION
This accounts for different 'hms' lengths, e.g.:
9:10:11
10:11:12